### PR TITLE
make installation a bit easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@
 playing around with civicapps restaurant inspection dataset
 
 Express.js app that maps Portland [resturant inspection info](http://www.civicapps.org/datasets/restaurant-inspections)
+
+# install and run
+
+```
+npm install
+npm start
+```

--- a/app.js
+++ b/app.js
@@ -9,54 +9,55 @@ var exphbs  = require('express-handlebars');
 var routes = require('./routes/index');
 var users = require('./routes/users');
 
-var app = express();
+module.exports = function createApp() {
+  var app = express();
 
-// view engine setup
-app.engine('handlebars', exphbs({defaultLayout: 'main'}));
-app.set('view engine', 'handlebars');
+  // view engine setup
+  app.engine('handlebars', exphbs({defaultLayout: 'main'}));
+  app.set('view engine', 'handlebars');
 
 
-// uncomment after placing your favicon in /public
-//app.use(favicon(__dirname + '/public/favicon.ico'));
-app.use(logger('dev'));
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
+  // uncomment after placing your favicon in /public
+  //app.use(favicon(__dirname + '/public/favicon.ico'));
+  app.use(logger('dev'));
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: false }));
+  app.use(cookieParser());
+  app.use(express.static(path.join(__dirname, 'public')));
 
-app.use('/', routes);
+  app.use('/', routes);
   
 
-// catch 404 and forward to error handler
-app.use(function(req, res, next) {
-  var err = new Error('Not Found');
-  err.status = 404;
-  next(err);
-});
+  // catch 404 and forward to error handler
+  app.use(function(req, res, next) {
+    var err = new Error('Not Found');
+    err.status = 404;
+    next(err);
+  });
 
-// error handlers
+  // error handlers
 
-// development error handler
-// will print stacktrace
-if (app.get('env') === 'development') {
+  // development error handler
+  // will print stacktrace
+  if (app.get('env') === 'development') {
+    app.use(function(err, req, res, next) {
+      res.status(err.status || 500);
+      res.render('error', {
+        message: err.message,
+        error: err
+      });
+    });
+  }
+
+  // production error handler
+  // no stacktraces leaked to user
   app.use(function(err, req, res, next) {
     res.status(err.status || 500);
     res.render('error', {
       message: err.message,
-      error: err
+      error: {}
     });
   });
+  
+  return app;
 }
-
-// production error handler
-// no stacktraces leaked to user
-app.use(function(err, req, res, next) {
-  res.status(err.status || 500);
-  res.render('error', {
-    message: err.message,
-    error: {}
-  });
-});
-
-
-module.exports = app;

--- a/app.js
+++ b/app.js
@@ -10,54 +10,54 @@ var routes = require('./routes/index');
 var users = require('./routes/users');
 
 module.exports = function createApp() {
-  var app = express();
-
-  // view engine setup
-  app.engine('handlebars', exphbs({defaultLayout: 'main'}));
-  app.set('view engine', 'handlebars');
-
-
-  // uncomment after placing your favicon in /public
-  //app.use(favicon(__dirname + '/public/favicon.ico'));
-  app.use(logger('dev'));
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({ extended: false }));
-  app.use(cookieParser());
-  app.use(express.static(path.join(__dirname, 'public')));
-
-  app.use('/', routes);
-  
-
-  // catch 404 and forward to error handler
-  app.use(function(req, res, next) {
-    var err = new Error('Not Found');
-    err.status = 404;
-    next(err);
-  });
-
-  // error handlers
-
-  // development error handler
-  // will print stacktrace
-  if (app.get('env') === 'development') {
-    app.use(function(err, req, res, next) {
-      res.status(err.status || 500);
-      res.render('error', {
-        message: err.message,
-        error: err
-      });
-    });
-  }
-
-  // production error handler
-  // no stacktraces leaked to user
-  app.use(function(err, req, res, next) {
-    res.status(err.status || 500);
-    res.render('error', {
-      message: err.message,
-      error: {}
-    });
-  });
-  
-  return app;
+	var app = express();
+	
+	// view engine setup
+	app.engine('handlebars', exphbs({defaultLayout: 'main'}));
+	app.set('view engine', 'handlebars');
+	
+	
+	// uncomment after placing your favicon in /public
+	//app.use(favicon(__dirname + '/public/favicon.ico'));
+	app.use(logger('dev'));
+	app.use(bodyParser.json());
+	app.use(bodyParser.urlencoded({ extended: false }));
+	app.use(cookieParser());
+	app.use(express.static(path.join(__dirname, 'public')));
+	
+	app.use('/', routes);
+	
+	
+	// catch 404 and forward to error handler
+	app.use(function(req, res, next) {
+	  var err = new Error('Not Found');
+	  err.status = 404;
+	  next(err);
+	});
+	
+	// error handlers
+	
+	// development error handler
+	// will print stacktrace
+	if (app.get('env') === 'development') {
+	  app.use(function(err, req, res, next) {
+	    res.status(err.status || 500);
+	    res.render('error', {
+	      message: err.message,
+	      error: err
+	    });
+	  });
+	}
+	
+	// production error handler
+	// no stacktraces leaked to user
+	app.use(function(err, req, res, next) {
+	  res.status(err.status || 500);
+	  res.render('error', {
+	    message: err.message,
+	    error: {}
+	  });
+	});
+	
+	return app;
 }

--- a/app.js
+++ b/app.js
@@ -10,54 +10,54 @@ var routes = require('./routes/index');
 var users = require('./routes/users');
 
 module.exports = function createApp() {
-	var app = express();
-	
-	// view engine setup
-	app.engine('handlebars', exphbs({defaultLayout: 'main'}));
-	app.set('view engine', 'handlebars');
-	
-	
-	// uncomment after placing your favicon in /public
-	//app.use(favicon(__dirname + '/public/favicon.ico'));
-	app.use(logger('dev'));
-	app.use(bodyParser.json());
-	app.use(bodyParser.urlencoded({ extended: false }));
-	app.use(cookieParser());
-	app.use(express.static(path.join(__dirname, 'public')));
-	
-	app.use('/', routes);
-	
-	
-	// catch 404 and forward to error handler
-	app.use(function(req, res, next) {
-	  var err = new Error('Not Found');
-	  err.status = 404;
-	  next(err);
-	});
-	
-	// error handlers
-	
-	// development error handler
-	// will print stacktrace
-	if (app.get('env') === 'development') {
-	  app.use(function(err, req, res, next) {
-	    res.status(err.status || 500);
-	    res.render('error', {
-	      message: err.message,
-	      error: err
-	    });
-	  });
-	}
-	
-	// production error handler
-	// no stacktraces leaked to user
-	app.use(function(err, req, res, next) {
-	  res.status(err.status || 500);
-	  res.render('error', {
-	    message: err.message,
-	    error: {}
-	  });
-	});
-	
-	return app;
+  var app = express();
+
+  // view engine setup
+  app.engine('handlebars', exphbs({defaultLayout: 'main'}));
+  app.set('view engine', 'handlebars');
+
+
+  // uncomment after placing your favicon in /public
+  //app.use(favicon(__dirname + '/public/favicon.ico'));
+  app.use(logger('dev'));
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: false }));
+  app.use(cookieParser());
+  app.use(express.static(path.join(__dirname, 'public')));
+
+  app.use('/', routes);
+  
+
+  // catch 404 and forward to error handler
+  app.use(function(req, res, next) {
+    var err = new Error('Not Found');
+    err.status = 404;
+    next(err);
+  });
+
+  // error handlers
+
+  // development error handler
+  // will print stacktrace
+  if (app.get('env') === 'development') {
+    app.use(function(err, req, res, next) {
+      res.status(err.status || 500);
+      res.render('error', {
+        message: err.message,
+        error: err
+      });
+    });
+  }
+
+  // production error handler
+  // no stacktraces leaked to user
+  app.use(function(err, req, res, next) {
+    res.status(err.status || 500);
+    res.render('error', {
+      message: err.message,
+      error: {}
+    });
+  });
+  
+  return app;
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node server.js"
   },
   "dependencies": {
     "body-parser": "~1.12.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,9 @@
+var createApp = require('./app.js');
+var app = createApp();
+
+var port = process.env.PORT || 3000;
+
+app.listen(port, function (err) {
+  if (err) throw err;
+  console.log('Listening on', port);
+})


### PR DESCRIPTION
hi, I thought this looked interesting (I have done work with civicapps data in the past and was curious), but the existing `npm start` command gave me this error:

```
🐈  npm start

> sheltr@0.0.0 start /Users/maxogden/src/js/eat-clean-pdx
> node ./bin/www

module.js:339
    throw err;
          ^
Error: Cannot find module '/Users/maxogden/src/js/eat-clean-pdx/bin/www'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Function.Module.runMain (module.js:472:10)
    at startup (node.js:124:18)
    at node.js:959:3
```

This PR adds a new file `server.js` that `require()`'s your `app.js` and calls `.listen` on it. It uses the `process.env.PORT` convention that Heroku uses, which makes it easier to deploy to places like Heroku in the future.

I also had to wrap the constructor code in `app.js` into a function so that `app.js` exported a sort of factory function that can be called later to initialize the app rather than the previous behavior which caused it to initialize the app at `require()` time.

But it totally works!

![screen shot 2015-05-06 at 10 22 59 am](https://cloud.githubusercontent.com/assets/39759/7499032/ed64bdd2-f3d9-11e4-856f-80301b1e33d0.png)
